### PR TITLE
修正翻译错误

### DIFF
--- a/raft-zh_cn.md
+++ b/raft-zh_cn.md
@@ -156,7 +156,7 @@ Raft 通过选举一个高贵的领导人，然后给予他全部的管理复制
 所有服务器：
 
 * 如果`commitIndex > lastApplied`，那么就 lastApplied 加一，并把`log[lastApplied]`应用到状态机中（5.3 节）
-* 如果接收到的 RPC 请求中，任期号`T > currentTerm`，那么就令 currentTerm 等于 T，并切换状态为跟随者（5.1 节）
+* 如果接收到的 RPC 请求或响应中，任期号`T > currentTerm`，那么就令 currentTerm 等于 T，并切换状态为跟随者（5.1 节）
 
 跟随者（5.2 节）：
 


### PR DESCRIPTION
原文

• If RPC request or **response** contains term T > currentTerm: set currentTerm = T, convert to follower (§5.1)

现在的翻译

如果接收到的 RPC 请求中，任期号T > currentTerm，那么就令 currentTerm 等于 T，并切换状态为跟随者（5.1 节）